### PR TITLE
All urls to be defined as objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,38 @@ Allows to format a given links ref object, to the format as described in RFC 598
   ```bash
     <https://api.github.com/user/9287/repos?page=3&per_page=100>; rel="next", <https://api.github.com/user/9287/repos?page=1&per_page=100>; rel="prev"; pet="cat", <https://api.github.com/user/9287/repos?page=5&per_page=100>; rel="last"
   ```
+
+4. You can also define values for `url` as an object. When this format is detected, the value will be formatted via Node's `url.format()` method.
+
+  ```js
+    var link = { next:
+       { page: '3',
+         per_page: '100',
+         rel: 'next',
+         url: {
+            protocol: 'https:',
+            slashes: true,
+            auth: null,
+            host: 'api.github.com',
+            port: null,
+            hostname: 'api.github.com',
+            hash: null,
+            search: '?client_id=1&client_secret=2&page=2&per_page=100',
+            query: 'client_id=1&client_secret=2&page=2&per_page=100',
+            pathname: '/user/9287/repos',
+            path: '/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100',
+            href: 'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100'
+         }
+        },
+      prev:
+       { page: '1',
+         per_page: '100',
+         rel: 'prev',
+         pet: 'cat',
+         url: 'https://api.github.com/user/9287/repos?page=1&per_page=100' },
+      last:
+       { page: '5',
+         per_page: '100',
+         rel: 'last',
+         url: 'https://api.github.com/user/9287/repos?page=5&per_page=100' } }
+  ```

--- a/src/format-link-urls.js
+++ b/src/format-link-urls.js
@@ -1,0 +1,23 @@
+var url = require('url');
+
+/**
+ * Loops through specified link objects, automatically formatting 'url' values that have been defined
+ * as objects via url.format().
+ * @param  {Object} linkProperty Unique properties link object
+ * @return {Object}
+ */
+module.exports = function formatLinkUrls(linkObject) {
+
+    for (linkPropertyName in linkObject) {
+
+        var linkProperty = linkObject[linkPropertyName];
+
+        if (typeof linkProperty.url === 'object') {
+            linkProperty.url = url.format(linkProperty.url);
+        }
+
+    }
+
+    return linkObject;
+
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+var formatLinkUrls = require('./format-link-urls');
 var groupRelAttributes = require('./group-link-rels');
 var transformLinkProperty = require('./transform-link-property');
 var formatLinkAttributes = require('./format-link-attributes');
@@ -9,6 +10,8 @@ var formatLinkAttributes = require('./format-link-attributes');
  */
 module.exports = function formatLinkHeader(linkObject) {
   if (linkObject === null || linkObject === undefined) return '';
+
+  formatLinkUrls(linkObject);
 
   return groupRelAttributes(linkObject)
     .map(function formatProperties(linkProperty) {

--- a/test/format-link-urls.js
+++ b/test/format-link-urls.js
@@ -1,0 +1,45 @@
+var formatLinkUrls = require('../src/format-link-urls');
+var expect = require('chai').expect;
+
+var linkObject = {
+    'linkAttributes1': {
+          rel: 'last',
+          hreflang: 'es',
+          content: 'boom',
+          url: 'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100'
+    },
+    'linkAttributes2': {
+          rel: 'last',
+          hreflang: 'es',
+          content: 'boom',
+          url: {
+            'protocol': 'https:',
+            'slashes': true,
+            'auth': null,
+            'host': 'api.github.com',
+            'port': null,
+            'hostname': 'api.github.com',
+            'hash': null,
+            'search': '?client_id=1&client_secret=2&page=2&per_page=100',
+            'query': 'client_id=1&client_secret=2&page=2&per_page=100',
+            'pathname': '/user/9287/repos',
+            'path': '/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100',
+            'href': 'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100'
+          }
+    }
+};
+
+describe('+ format-link-urls', function() {
+  describe('#call', function() {
+    var links = formatLinkUrls(linkObject);
+
+    it('it should not modify URLs that are specified as strings', function() {
+        expect(links.linkAttributes1.url).to.be.equals('https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100');
+    });
+
+    it('it should format urls that are specified as objects', function() {
+        expect(links.linkAttributes2.url).to.be.equals('https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100');
+    });
+
+  });
+});


### PR DESCRIPTION
This PR introduces a backwards-compatible feature: the ability to define values for `url` as an object. When defined in this manner, the url is automatically converted to its string equivalent via Node's `url.format()` method.
